### PR TITLE
baseline

### DIFF
--- a/backend/amazonclouddrive/amazonclouddrive.go
+++ b/backend/amazonclouddrive/amazonclouddrive.go
@@ -983,6 +983,16 @@ func (o *Object) Size() int64 {
 	return 0 // Object is likely PENDING
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // readMetaData gets the metadata if it hasn't already been fetched
 //
 // it also sets the info
@@ -1035,10 +1045,10 @@ func (o *Object) ModTime() time.Time {
 	return modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	// FIXME not implemented
-	return fs.ErrorCantSetModTime
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns a boolean showing whether this object storable

--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -813,6 +813,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 func (o *Object) setMetadata(metadata azblob.Metadata) {
 	if len(metadata) > 0 {
 		o.meta = metadata
@@ -934,8 +944,8 @@ func (o *Object) ModTime() (result time.Time) {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	// Make sure o.meta is not nil
 	if o.meta == nil {
 		o.meta = make(map[string]string, 1)

--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1023,6 +1023,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // decodeMetaDataRaw sets the metadata from the data passed in
 //
 // Sets
@@ -1143,10 +1153,10 @@ func (o *Object) ModTime() (result time.Time) {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	// Not possible with B2
-	return fs.ErrorCantSetModTime
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns if this object is storable

--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -940,6 +940,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the metadata from info
 func (o *Object) setMetaData(info *api.Item) (err error) {
 	if info.Type != api.ItemTypeFile {
@@ -1005,8 +1015,8 @@ func (o *Object) setModTime(modTime time.Time) (*api.Item, error) {
 	return info, err
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	info, err := o.setModTime(modTime)
 	if err != nil {
 		return err

--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -678,7 +678,7 @@ func TestInternalChangeSeenAfterDirCacheFlush(t *testing.T) {
 	o, err := cfs.UnWrap().NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	wrappedTime := time.Now().Add(-1 * time.Hour)
-	err = o.SetModTime(wrappedTime)
+	err = o.SetMeta(wrappedTime, wrappedTime, nil)
 	require.NoError(t, err)
 
 	// get a new instance from the cache
@@ -721,7 +721,7 @@ func TestInternalChangeSeenAfterRc(t *testing.T) {
 	o, err := cfs.UnWrap().NewObject(runInstance.encryptRemoteIfNeeded(t, "data.bin"))
 	require.NoError(t, err)
 	wrappedTime := time.Now().Add(-1 * time.Hour)
-	err = o.SetModTime(wrappedTime)
+	err = o.SetMeta(wrappedTime, wrappedTime, nil)
 	require.NoError(t, err)
 
 	// get a new instance from the cache

--- a/backend/cache/directory.go
+++ b/backend/cache/directory.go
@@ -18,6 +18,7 @@ type Directory struct {
 	Name         string `json:"name"`    // name of the directory
 	Dir          string `json:"dir"`     // abs path of the directory
 	CacheModTime int64  `json:"modTime"` // modification or creation time - IsZero for unknown
+	CacheChgTime int64  `json:"chgTime"` // change time - IsZero for unknown
 	CacheSize    int64  `json:"size"`    // size of directory and contents or -1 if unknown
 
 	CacheItems int64      `json:"items"`     // number of objects or -1 for unknown
@@ -115,9 +116,19 @@ func (d *Directory) ModTime() time.Time {
 	return time.Unix(0, d.CacheModTime)
 }
 
+// ChgTime returns the cached ChgTime
+func (d *Directory) ChgTime() time.Time {
+	return time.Unix(0, d.CacheChgTime)
+}
+
 // Size returns the cached Size
 func (d *Directory) Size() int64 {
 	return d.CacheSize
+}
+
+// Meta returns the meta of the file
+func (d *Directory) Meta() map[string]string {
+	return nil
 }
 
 // Items returns the cached Items

--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -28,6 +28,7 @@ type Object struct {
 	Name          string               `json:"name"`     // name of the directory
 	Dir           string               `json:"dir"`      // abs path of the object
 	CacheModTime  int64                `json:"modTime"`  // modification or creation time - IsZero for unknown
+	CacheChgTime  int64                `json:"chgTime"`  // modification or creation time - IsZero for unknown
 	CacheSize     int64                `json:"size"`     // size of directory and contents or -1 if unknown
 	CacheStorable bool                 `json:"storable"` // says whether this object can be stored
 	CacheType     string               `json:"cacheType"`
@@ -59,6 +60,7 @@ func NewObject(f *Fs, remote string) *Object {
 		Name:          cleanPath(name),
 		Dir:           cleanPath(dir),
 		CacheModTime:  time.Now().UnixNano(),
+		CacheChgTime:  time.Now().UnixNano(),
 		CacheSize:     0,
 		CacheStorable: false,
 		CacheType:     cacheType,
@@ -188,18 +190,20 @@ func (o *Object) refreshFromSource(force bool) error {
 	return nil
 }
 
-// SetModTime sets the ModTime of this object
-func (o *Object) SetModTime(t time.Time) error {
+// SetMeta sets the ModTime of this object
+func (o *Object) SetMeta(t time.Time, t2 time.Time, m map[string]string) error {
 	if err := o.refreshFromSource(false); err != nil {
 		return err
 	}
 
-	err := o.Object.SetModTime(t)
+	err := o.Object.SetMeta(t, t2, m)
 	if err != nil {
 		return err
 	}
 
 	o.CacheModTime = t.UnixNano()
+	o.CacheChgTime = t2.UnixNano()
+	// TBD cache meta
 	o.persist()
 	fs.Debugf(o, "updated ModTime: %v", t)
 

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1805,6 +1805,16 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the fs data from a drive.File
 func (o *Object) setMetaData(info *drive.File) {
 	o.id = info.Id
@@ -1896,8 +1906,8 @@ func (o *Object) ModTime() time.Time {
 	return modTime
 }
 
-// SetModTime sets the modification time of the drive fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the drive fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	err := o.readMetaData()
 	if err != nil {
 		return err

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -834,6 +834,16 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetadataFromEntry sets the fs data from a files.FileMetadata
 //
 // This isn't a complete set of metadata and has an inacurate date
@@ -889,14 +899,14 @@ func (o *Object) ModTime() time.Time {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
+// SetMeta sets the modification time of the local fs object
 //
 // Commits the datastore
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	// Dropbox doesn't have a way of doing this so returning this
 	// error will cause the file to be deleted first then
 	// re-uploaded to set the time.
-	return fs.ErrorCantSetModTimeWithoutDelete
+	return fs.ErrorCantSetMetaWithoutDelete
 }
 
 // Storable returns whether this object is storable

--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -612,13 +612,23 @@ func (o *Object) Size() int64 {
 	return int64(o.info.Size)
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // ModTime returns the modification time of the object
 func (o *Object) ModTime() time.Time {
 	return o.info.ModTime
 }
 
-// SetModTime sets the modification time of the object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	return nil
 }
 

--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -804,6 +804,16 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the fs data from a storage.Object
 func (o *Object) setMetaData(info *storage.Object) {
 	o.url = info.MediaLink
@@ -882,8 +892,8 @@ func metadataFromModTime(modTime time.Time) map[string]string {
 	return metadata
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) (err error) {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) (err error) {
 	// This only adds metadata so will perserve other metadata
 	object := storage.Object{
 		Bucket:   o.fs.bucket,

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -402,6 +402,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // ModTime returns the modification time of the remote http file
 func (o *Object) ModTime() time.Time {
 	return o.modTime
@@ -430,10 +440,10 @@ func (o *Object) stat() error {
 	return nil
 }
 
-// SetModTime sets the modification and access time to the specified time
+// SetMeta sets the modification and access time to the specified time
 //
 // it also updates the info field
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	return errorReadOnly
 }
 

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -715,6 +715,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // MimeType of an Object if known, "" otherwise
 func (o *Object) MimeType() string {
 	return o.mimeType
@@ -754,9 +764,9 @@ func (o *Object) ModTime() time.Time {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
-	return fs.ErrorCantSetModTime
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns a boolean showing whether this object storable

--- a/backend/mega/mega.go
+++ b/backend/mega/mega.go
@@ -902,6 +902,16 @@ func (o *Object) Size() int64 {
 	return o.info.GetSize()
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the metadata from info
 func (o *Object) setMetaData(info *mega.Node) (err error) {
 	if info.GetType() != mega.FILE {
@@ -937,9 +947,9 @@ func (o *Object) ModTime() time.Time {
 	return o.info.GetTimeStamp()
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
-	return fs.ErrorCantSetModTime
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns a boolean showing whether this object storable

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -848,7 +848,7 @@ func (f *Fs) Copy(src fs.Object, remote string) (fs.Object, error) {
 	// Copy does NOT copy the modTime from the source and there seems to
 	// be no way to set date before
 	// This will create TWO versions on OneDrive
-	err = dstObj.SetModTime(srcObj.ModTime())
+	err = dstObj.SetMeta(srcObj.ModTime(), srcObj.ChgTime(), srcObj.Meta())
 	if err != nil {
 		return nil, err
 	}
@@ -1112,6 +1112,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the metadata from info
 func (o *Object) setMetaData(info *api.Item) (err error) {
 	if info.GetFolder() != nil {
@@ -1212,8 +1222,8 @@ func (o *Object) setModTime(modTime time.Time) (*api.Item, error) {
 	return info, err
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	info, err := o.setModTime(modTime)
 	if err != nil {
 		return err

--- a/backend/opendrive/opendrive.go
+++ b/backend/opendrive/opendrive.go
@@ -830,6 +830,16 @@ func (o *Object) Size() int64 {
 	return o.size // Object is likely PENDING
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // ModTime returns the modification time of the object
 //
 //
@@ -839,9 +849,9 @@ func (o *Object) ModTime() time.Time {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
-	// fs.Debugf(nil, "SetModTime(%v)", modTime.String())
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
+	// fs.Debugf(nil, "SetMeta(%v)", modTime.String())
 	opts := rest.Opts{
 		Method:     "PUT",
 		NoResponse: true,
@@ -1040,7 +1050,7 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 	o.size = closeResponse.Size
 
 	// Set the mod time now
-	err = o.SetModTime(modTime)
+	err = o.SetMeta(modTime, src.ChgTime(), src.Meta())
 	if err != nil {
 		return err
 	}

--- a/backend/pcloud/pcloud.go
+++ b/backend/pcloud/pcloud.go
@@ -914,6 +914,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the metadata from info
 func (o *Object) setMetaData(info *api.Item) (err error) {
 	if info.IsFolder {
@@ -966,11 +976,11 @@ func (o *Object) ModTime() time.Time {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	// Pcloud doesn't have a way of doing this so returning this
 	// error will cause the file to be re-uploaded to set the time.
-	return fs.ErrorCantSetModTime
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns a boolean showing whether this object storable

--- a/backend/qingstor/qingstor.go
+++ b/backend/qingstor/qingstor.go
@@ -842,8 +842,8 @@ func (o *Object) ModTime() time.Time {
 	return modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	err := o.readMetaData()
 	if err != nil {
 		return err
@@ -852,7 +852,7 @@ func (o *Object) SetModTime(modTime time.Time) error {
 	mimeType := fs.MimeType(o)
 
 	if o.size >= maxSizeForCopy {
-		fs.Debugf(o, "SetModTime is unsupported for objects bigger than %v bytes", fs.SizeSuffix(maxSizeForCopy))
+		fs.Debugf(o, "SetMeta is unsupported for objects bigger than %v bytes", fs.SizeSuffix(maxSizeForCopy))
 		return nil
 	}
 	// Copy the object to itself to update the metadata
@@ -986,6 +986,16 @@ func (o *Object) Remote() string {
 // Size returns the size of the file
 func (o *Object) Size() int64 {
 	return o.size
+}
+
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
 }
 
 // MimeType of an Object if known, "" otherwise

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1460,9 +1460,9 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		}
 	}
 
-	if !o.fs.opt.DisableChecksum && size > uploader.PartSize {
+	if !o.fs.opt.DisableChecksum && size > uploader.PartSize ||
+		fs.Config.ForceMd5 {
 		hash, err := src.Hash(hash.MD5)
-
 		if err == nil && matchMd5.MatchString(hash) {
 			hashBytes, err := hex.DecodeString(hash)
 

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -115,7 +115,7 @@ type Options struct {
 	DisableHashCheck  bool   `config:"disable_hashcheck"`
 	AskPassword       bool   `config:"ask_password"`
 	PathOverride      string `config:"path_override"`
-	SetModTime        bool   `config:"set_modtime"`
+	SetMeta           bool   `config:"set_meta"`
 }
 
 // Fs stores the interface to the remote SFTP files
@@ -813,6 +813,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // ModTime returns the modification time of the remote sftp file
 func (o *Object) ModTime() time.Time {
 	return o.modTime
@@ -858,24 +868,24 @@ func (o *Object) stat() error {
 	return nil
 }
 
-// SetModTime sets the modification and access time to the specified time
+// SetMeta sets the modification and access time to the specified time
 //
 // it also updates the info field
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	c, err := o.fs.getSftpConnection()
 	if err != nil {
-		return errors.Wrap(err, "SetModTime")
+		return errors.Wrap(err, "SetMeta")
 	}
-	if o.fs.opt.SetModTime {
-		err = c.sftpClient.Chtimes(o.path(), modTime, modTime)
+	if o.fs.opt.SetMeta {
+		err = c.sftpClient.Chtimes(o.path(), modTime, chgTime)
 		o.fs.putSftpConnection(&c, err)
 		if err != nil {
-			return errors.Wrap(err, "SetModTime failed")
+			return errors.Wrap(err, "SetMeta failed")
 		}
 	}
 	err = o.stat()
 	if err != nil {
-		return errors.Wrap(err, "SetModTime stat failed")
+		return errors.Wrap(err, "SetMeta stat failed")
 	}
 	return nil
 }
@@ -1004,9 +1014,9 @@ func (o *Object) Update(in io.Reader, src fs.ObjectInfo, options ...fs.OpenOptio
 		remove()
 		return errors.Wrap(err, "Update Close failed")
 	}
-	err = o.SetModTime(src.ModTime())
+	err = o.SetMeta(src.ModTime(), src.ChgTime(), src.Meta())
 	if err != nil {
-		return errors.Wrap(err, "Update SetModTime failed")
+		return errors.Wrap(err, "Update SetMeta failed")
 	}
 	return nil
 }

--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -771,6 +771,16 @@ func (o *Object) Size() int64 {
 	return o.info.Bytes
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil; // TBD
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // readMetaData gets the metadata if it hasn't already been fetched
 //
 // it also sets the info
@@ -814,8 +824,8 @@ func (o *Object) ModTime() time.Time {
 	return modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, m map[string]string) error {
 	err := o.readMetaData()
 	if err != nil {
 		return err

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -13,7 +13,7 @@ package webdav
 // https://github.com/nextcloud/server/issues/6129
 // owncloud seems to have checksums as metadata though - can read them
 
-// SetModTime might be possible
+// SetMeta might be possible
 // https://stackoverflow.com/questions/3579608/webdav-can-a-client-modify-the-mtime-of-a-file
 // ...support for a PROPSET to lastmodified (mind the missing get) which does the utime() call might be an option.
 // For example the ownCloud WebDAV server does it that way.
@@ -875,6 +875,16 @@ func (o *Object) Size() int64 {
 	return o.size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // setMetaData sets the metadata from info
 func (o *Object) setMetaData(info *api.Prop) (err error) {
 	o.hasMetaData = true
@@ -910,9 +920,9 @@ func (o *Object) ModTime() time.Time {
 	return o.modTime
 }
 
-// SetModTime sets the modification time of the local fs object
-func (o *Object) SetModTime(modTime time.Time) error {
-	return fs.ErrorCantSetModTime
+// SetMeta sets the modification time of the local fs object
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
+	return fs.ErrorCantSetMeta
 }
 
 // Storable returns a boolean showing whether this object storable

--- a/backend/yandex/yandex.go
+++ b/backend/yandex/yandex.go
@@ -545,6 +545,16 @@ func (o *Object) Size() int64 {
 	return size
 }
 
+// Meta returns the meta of the file
+func (o *Object) Meta() map[string]string {
+	return nil
+}
+
+// ChgTime returns the change date of the file
+func (o *Object) ChgTime() time.Time {
+	return time.Now()
+}
+
 // ModTime returns the modification time of the object
 //
 // It attempts to read the objects mtime and if that isn't present the
@@ -568,10 +578,10 @@ func (o *Object) Remove() error {
 	return o.fs.yd.Delete(o.remotePath(), true)
 }
 
-// SetModTime sets the modification time of the local fs object
+// SetMeta sets the modification time of the local fs object
 //
 // Commits the datastore
-func (o *Object) SetModTime(modTime time.Time) error {
+func (o *Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	remote := o.remotePath()
 	// set custom_property 'rclone_modified' of object to modTime
 	err := o.fs.yd.SetCustomProperty(remote, "rclone_modified", modTime.Format(time.RFC3339Nano))
@@ -617,7 +627,7 @@ func (o *Object) Update(in0 io.Reader, src fs.ObjectInfo, options ...fs.OpenOpti
 		o.modTime = modTime
 		o.md5sum = "" // according to unit tests after put the md5 is empty.
 		//and set modTime of uploaded file
-		err = o.SetModTime(modTime)
+		err = o.SetMeta(modTime, src.ChgTime(), src.Meta())
 	}
 	return err
 }

--- a/cmd/lsjson/lsjson.go
+++ b/cmd/lsjson/lsjson.go
@@ -24,6 +24,7 @@ var (
 	showEncrypted bool
 	showOrigIDs   bool
 	noModTime     bool
+	noChgTime     bool
 )
 
 func init() {
@@ -31,6 +32,7 @@ func init() {
 	commandDefintion.Flags().BoolVarP(&recurse, "recursive", "R", false, "Recurse into the listing.")
 	commandDefintion.Flags().BoolVarP(&showHash, "hash", "", false, "Include hashes in the output (may take longer).")
 	commandDefintion.Flags().BoolVarP(&noModTime, "no-modtime", "", false, "Don't read the modification time (can speed things up).")
+	commandDefintion.Flags().BoolVarP(&noChgTime, "no-chgtime", "", false, "Don't read the change time (can speed things up).")
 	commandDefintion.Flags().BoolVarP(&showEncrypted, "encrypted", "M", false, "Show the encrypted names.")
 	commandDefintion.Flags().BoolVarP(&showOrigIDs, "original", "", false, "Show the ID of the underlying Object.")
 }
@@ -43,6 +45,7 @@ type lsJSON struct {
 	Size      int64
 	MimeType  string    `json:",omitempty"`
 	ModTime   Timestamp //`json:",omitempty"`
+	ChgTime   Timestamp //`json:",omitempty"`
 	IsDir     bool
 	Hashes    map[string]string `json:",omitempty"`
 	ID        string            `json:",omitempty"`
@@ -79,6 +82,7 @@ The output is an array of Items, where each Item looks like this
       "IsDir" : false,
       "MimeType" : "application/octet-stream",
       "ModTime" : "2017-05-31T16:15:57.034468261+01:00",
+      "ChgTime" : "2017-05-31T16:15:57.034468261+01:00",
       "Name" : "file.txt",
       "Encrypted" : "v0qpsdq8anpci8n929v3uu9338",
       "Path" : "full/path/goes/here/file.txt",
@@ -88,6 +92,8 @@ The output is an array of Items, where each Item looks like this
 If --hash is not specified the Hashes property won't be emitted.
 
 If --no-modtime is specified then ModTime will be blank.
+
+If --no-chgtime is specified then ChgTime will be blank.
 
 If --encrypted is not specified the Encrypted won't be emitted.
 
@@ -136,6 +142,9 @@ can be processed line by line as each item is written one to a line.
 					}
 					if !noModTime {
 						item.ModTime = Timestamp(entry.ModTime())
+					}
+					if !noChgTime {
+						item.ChgTime = Timestamp(entry.ChgTime())
 					}
 					if cipher != nil {
 						switch entry.(type) {

--- a/cmd/touch/touch.go
+++ b/cmd/touch/touch.go
@@ -64,7 +64,7 @@ func Touch(fsrc fs.Fs, srcFileName string) error {
 		}
 		return nil
 	}
-	err = file.SetModTime(timeAtr)
+	err = file.SetMeta(timeAtr, timeAtr, nil)
 	if err != nil {
 		return errors.Wrap(err, "touch: couldn't set mod time")
 	}

--- a/fs/config.go
+++ b/fs/config.go
@@ -85,6 +85,7 @@ type ConfigInfo struct {
 	StatsOneLine          bool
 	Progress              bool
 	UseCtime              bool
+	MdOnly		      bool
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config.go
+++ b/fs/config.go
@@ -86,6 +86,7 @@ type ConfigInfo struct {
 	Progress              bool
 	UseCtime              bool
 	MdOnly		      bool
+	ForceMd5	      bool
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config.go
+++ b/fs/config.go
@@ -62,7 +62,7 @@ type ConfigInfo struct {
 	MaxDepth              int
 	IgnoreSize            bool
 	IgnoreChecksum        bool
-	NoUpdateModTime       bool
+	NoUpdateMeta          bool
 	DataRateUnit          string
 	BackupDir             string
 	Suffix                string
@@ -84,6 +84,7 @@ type ConfigInfo struct {
 	MaxBacklog            int
 	StatsOneLine          bool
 	Progress              bool
+	UseCtime              bool
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -64,7 +64,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.IgnoreSize, "ignore-size", "", false, "Ignore size when skipping use mod-time or checksum.")
 	flags.BoolVarP(flagSet, &fs.Config.IgnoreChecksum, "ignore-checksum", "", fs.Config.IgnoreChecksum, "Skip post copy check of checksums.")
 	flags.BoolVarP(flagSet, &noTraverse, "no-traverse", "", noTraverse, "Obsolete - does nothing.")
-	flags.BoolVarP(flagSet, &fs.Config.NoUpdateModTime, "no-update-modtime", "", fs.Config.NoUpdateModTime, "Don't update destination mod-time if files identical.")
+	flags.BoolVarP(flagSet, &fs.Config.NoUpdateMeta, "no-update-meta", "", fs.Config.NoUpdateMeta, "Don't update destination mod-time, chg-time and meta if files identical.")
 	flags.StringVarP(flagSet, &fs.Config.BackupDir, "backup-dir", "", fs.Config.BackupDir, "Make backups into hierarchy based in DIR.")
 	flags.StringVarP(flagSet, &fs.Config.Suffix, "suffix", "", fs.Config.Suffix, "Suffix for use with --backup-dir.")
 	flags.BoolVarP(flagSet, &fs.Config.UseListR, "fast-list", "", fs.Config.UseListR, "Use recursive list if available. Uses more memory but fewer transactions.")
@@ -86,6 +86,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.IntVarP(flagSet, &fs.Config.MaxBacklog, "max-backlog", "", fs.Config.MaxBacklog, "Maximum number of objects in sync or check backlog.")
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLine, "stats-one-line", "", fs.Config.StatsOneLine, "Make the stats fit on one line.")
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
+	flags.BoolVarP(flagSet, &fs.Config.UseCtime, "use-ctime", "", fs.Config.UseCtime, "Use change time instead of mod time for operations.")
 }
 
 // SetFlags converts any flags into config which weren't straight foward

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -88,6 +88,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
 	flags.BoolVarP(flagSet, &fs.Config.UseCtime, "use-ctime", "", fs.Config.UseCtime, "Use change time instead of mod time for operations.")
 	flags.BoolVarP(flagSet, &fs.Config.MdOnly, "md-only", "", fs.Config.MdOnly, "Only upload metadata changes.")
+	flags.BoolVarP(flagSet, &fs.Config.ForceMd5, "force-md5", "", fs.Config.ForceMd5, "Force the upload of the Md5.")
 }
 
 // SetFlags converts any flags into config which weren't straight foward

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -87,6 +87,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLine, "stats-one-line", "", fs.Config.StatsOneLine, "Make the stats fit on one line.")
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
 	flags.BoolVarP(flagSet, &fs.Config.UseCtime, "use-ctime", "", fs.Config.UseCtime, "Use change time instead of mod time for operations.")
+	flags.BoolVarP(flagSet, &fs.Config.MdOnly, "md-only", "", fs.Config.MdOnly, "Only upload metadata changes.")
 }
 
 // SetFlags converts any flags into config which weren't straight foward

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -6,7 +6,9 @@ import "time"
 type Dir struct {
 	remote  string    // name of the directory
 	modTime time.Time // modification or creation time - IsZero for unknown
+	chgTime time.Time // change time - IsZero for unknown
 	size    int64     // size of directory and contents or -1 if unknown
+	meta    map[string]string // The object metadata if known - may be nil
 	items   int64     // number of objects or -1 for unknown
 	id      string    // optional ID
 }
@@ -67,9 +69,22 @@ func (d *Dir) ModTime() time.Time {
 	return time.Now()
 }
 
+// ChgTime returns the change date of the file
+func (d *Dir) ChgTime() time.Time {
+	if !d.chgTime.IsZero() {
+		return d.chgTime
+	}
+	return time.Now()
+}
+
 // Size returns the size of the file
 func (d *Dir) Size() int64 {
 	return d.size
+}
+
+// Meta returns the meta of the file
+func (d *Dir) Meta() map[string]string {
+	return d.meta
 }
 
 // SetSize sets the size of the directory

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -48,8 +48,8 @@ var (
 	ErrorCantMove                    = errors.New("can't move object - incompatible remotes")
 	ErrorCantDirMove                 = errors.New("can't move directory - incompatible remotes")
 	ErrorDirExists                   = errors.New("can't copy directory - destination already exists")
-	ErrorCantSetModTime              = errors.New("can't set modified time")
-	ErrorCantSetModTimeWithoutDelete = errors.New("can't set modified time without deleting existing object")
+	ErrorCantSetMeta                 = errors.New("can't set meta")
+	ErrorCantSetMetaWithoutDelete    = errors.New("can't set modified time and meta without deleting existing object")
 	ErrorDirNotFound                 = errors.New("directory not found")
 	ErrorObjectNotFound              = errors.New("object not found")
 	ErrorLevelNotSupported           = errors.New("level value not supported")
@@ -176,6 +176,35 @@ type OptionExample struct {
 	Provider string
 }
 
+// Additional metadata
+const (
+	MetaDev		= "Dev"
+	MetaIno		= "Ino"
+	MetaNlink	= "Nlink"
+	MetaMode	= "Mode"
+	MetaUid		= "Uid"
+	MetaGid		= "Gid"
+	MetaSize        = "Size"
+	MetaRdev        = "Rdev"
+	MetaBlksize     = "Blksize"
+	MetaBlocks      = "Blocks"
+)
+
+func Int64ToString(ns int64) string {
+        result := fmt.Sprintf("%d", ns)
+        return result
+}
+
+func Uint64ToString(ns uint64) string {
+        result := fmt.Sprintf("%d", ns)
+        return result
+}
+
+func Uint32ToString(ns uint32) string {
+        result := fmt.Sprintf("%d", ns)
+        return result
+}
+
 // Register a filesystem
 //
 // Fs modules  should use this in an init() function
@@ -249,8 +278,8 @@ type Info interface {
 type Object interface {
 	ObjectInfo
 
-	// SetModTime sets the metadata on the object to set the modification date
-	SetModTime(time.Time) error
+	// SetMeta sets the modtime, chgTime and meta key/values on the object
+	SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error
 
 	// Open opens the file for read.  Call Close() on the returned io.ReadCloser
 	Open(options ...OpenOption) (io.ReadCloser, error)
@@ -291,8 +320,14 @@ type DirEntry interface {
 	// It should return a best guess if one isn't available
 	ModTime() time.Time
 
+	// ChgTime return the metadata and attributes change date
+	// of the file
+	ChgTime() time.Time
+	
 	// Size returns the size of the file
 	Size() int64
+
+	Meta() map[string]string
 }
 
 // Directory is a filesystem like directory provided by an Fs

--- a/fs/list/list_test.go
+++ b/fs/list/list_test.go
@@ -89,6 +89,8 @@ type unknownDirEntry string
 func (o unknownDirEntry) String() string         { return string(o) }
 func (o unknownDirEntry) Remote() string         { return string(o) }
 func (o unknownDirEntry) ModTime() (t time.Time) { return t }
+func (o unknownDirEntry) ChgTime() (t time.Time) { return t }
+func (o unknownDirEntry) Meta() (m map[string]string) { return m }
 func (o unknownDirEntry) Size() int64            { return 0 }
 
 func TestFilterAndSortUnknown(t *testing.T) {

--- a/fs/object/object.go
+++ b/fs/object/object.go
@@ -37,6 +37,7 @@ func NewStaticObjectInfo(remote string, modTime time.Time, size int64, storable 
 type staticObjectInfo struct {
 	remote   string
 	modTime  time.Time
+	chgTime  time.Time
 	size     int64
 	storable bool
 	hashes   map[hash.Type]string
@@ -47,7 +48,9 @@ func (i *staticObjectInfo) Fs() fs.Info        { return i.fs }
 func (i *staticObjectInfo) Remote() string     { return i.remote }
 func (i *staticObjectInfo) String() string     { return i.remote }
 func (i *staticObjectInfo) ModTime() time.Time { return i.modTime }
+func (i *staticObjectInfo) ChgTime() time.Time { return i.chgTime }
 func (i *staticObjectInfo) Size() int64        { return i.size }
+func (i *staticObjectInfo) Meta() map[string]string { return nil }
 func (i *staticObjectInfo) Storable() bool     { return i.storable }
 func (i *staticObjectInfo) Hash(h hash.Type) (string, error) {
 	if len(i.hashes) == 0 {
@@ -132,6 +135,8 @@ var _ fs.Fs = MemoryFs
 type MemoryObject struct {
 	remote  string
 	modTime time.Time
+	chgTime time.Time
+	meta    map[string]string
 	content []byte
 }
 
@@ -169,9 +174,19 @@ func (o *MemoryObject) ModTime() time.Time {
 	return o.modTime
 }
 
+// ChgTime returns the change date of the file
+func (o *MemoryObject) ChgTime() time.Time {
+	return o.chgTime
+}
+
 // Size returns the size of the file
 func (o *MemoryObject) Size() int64 {
 	return int64(len(o.content))
+}
+
+// Meta returns the meta of the file
+func (o *MemoryObject) Meta() map[string]string {
+	return nil
 }
 
 // Storable says whether this object can be stored
@@ -192,9 +207,11 @@ func (o *MemoryObject) Hash(h hash.Type) (string, error) {
 	return hash.Sums()[h], nil
 }
 
-// SetModTime sets the metadata on the object to set the modification date
-func (o *MemoryObject) SetModTime(modTime time.Time) error {
+// SetMeta sets the metadata on the object to set the modification date
+func (o *MemoryObject) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	o.modTime = modTime
+	o.chgTime = chgTime
+	o.meta = meta
 	return nil
 }
 

--- a/fs/object/object_test.go
+++ b/fs/object/object_test.go
@@ -104,7 +104,7 @@ func TestMemoryObject(t *testing.T) {
 	assert.Equal(t, "3e2e95f5ad970eadfa7e17eaf73da97024aa5359", Hash)
 
 	newNow := now.Add(time.Minute)
-	err = o.SetModTime(newNow)
+	err = o.SetMeta(newNow, newNow, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, newNow, o.ModTime())
 

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -420,9 +420,9 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 		return
 	}
 
-	fs.Config.NoUpdateModTime = true
+	fs.Config.NoUpdateMeta = true
 	defer func() {
-		fs.Config.NoUpdateModTime = false
+		fs.Config.NoUpdateMeta = false
 	}()
 
 	file1 := r.WriteFile("empty space", "", t2)

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -870,13 +870,13 @@ func Run(t *testing.T, opt *Opt) {
 		}
 	})
 
-	// TestObjectSetModTime tests that SetModTime works
-	t.Run("TestObjectSetModTime", func(t *testing.T) {
+	// TestObjectSetMeta tests that SetMeta works
+	t.Run("TestObjectSetMeta", func(t *testing.T) {
 		skipIfNotOk(t)
 		newModTime := fstest.Time("2011-12-13T14:15:16.999999999Z")
 		obj := findObject(t, remote, file1.Path)
-		err := obj.SetModTime(newModTime)
-		if err == fs.ErrorCantSetModTime || err == fs.ErrorCantSetModTimeWithoutDelete {
+		err := obj.SetMeta(newModTime, newModTime, nil)
+		if err == fs.ErrorCantSetMeta || err == fs.ErrorCantSetMetaWithoutDelete {
 			t.Log(err)
 			return
 		}

--- a/fstest/mockobject/mockobject.go
+++ b/fstest/mockobject/mockobject.go
@@ -49,6 +49,14 @@ func (o Object) ModTime() (t time.Time) {
 	return t
 }
 
+func (o Object) ChgTime() (t time.Time) {
+	return t
+}
+
+func (o Object) Meta() (m map[string]string) {
+	return m
+}
+
 // Size returns the size of the file
 func (o Object) Size() int64 { return 0 }
 
@@ -57,8 +65,8 @@ func (o Object) Storable() bool {
 	return true
 }
 
-// SetModTime sets the metadata on the object to set the modification date
-func (o Object) SetModTime(time.Time) error {
+// SetMeta sets the modification time of the local fs object
+func (o Object) SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string) error {
 	return errNotImpl
 }
 

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -305,11 +305,11 @@ func (f *File) applyPendingModTime() error {
 		return errors.New("Cannot apply ModTime, file object is not available")
 	}
 
-	err := f.o.SetModTime(f.pendingModTime)
+	err := f.o.SetMeta(f.pendingModTime, f.pendingModTime, nil)
 	switch err {
 	case nil:
 		fs.Debugf(f.o, "File.applyPendingModTime OK")
-	case fs.ErrorCantSetModTime, fs.ErrorCantSetModTimeWithoutDelete:
+	case fs.ErrorCantSetMeta, fs.ErrorCantSetMetaWithoutDelete:
 		// do nothing, in order to not break "touch somefile" if it exists already
 	default:
 		fs.Errorf(f, "File.applyPendingModTime error: %v", err)


### PR DESCRIPTION
The goal of this PR is to be able to detect changes in the metadata subsystem if the source (e.g. on a filesystem tracking the ctime instead of the mtime).

- For this we need to extend the old SetModTime(time time.Time) API by a more generic SetMeta(modTime time.Time, chgTime time.Time, meta map[string]string). And also adding 2 new methods to the Object class ChgTime() that returns the ctime and Meta() that returns the usermd dictionary (e.g. xattr).
- Collect all system metadata in local.go to be exported (e.g. uid, gid, etc) but no support for xattr (it will be relatively easy to implement).
- All *ModTime* related methods and errors have been renamed to the more generic *Meta*: THIS IS A  RELATIVELY INTRUSIVE CHANGE!!! => the PR may not be accepted upstream, I am going to see with the repo owner if they are interested.
- All tests pass, because we made sure to be backward compatible.
- Implement a specific option --md-only to force to never upload content (for now only honored by S3 backend)

Possible improvements:
- Implement xattr in local.go
- Implement proper support of ChgTime(), Meta() and SetMeta() in the different backends, for now only local->S3 have been manually tested
- Implement unit tests for the new ChgTime(), Meta() and SetMeta()
